### PR TITLE
Fix Models not found on case sensitive system

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,7 +32,7 @@ class ServiceProvider extends BaseServiceProvider
             ], 'laraciproid-seeds');
 
             $this->publishes([
-                __DIR__.'/Models/' => app_path('Models'),
+                __DIR__.'/models/' => app_path('models'),
             ], 'laraciproid-models');
 
             $this->publishes([


### PR DESCRIPTION
Different case on models folder and it's declaration in ServiceProvider resulting on "Models not found" when using case sensitive OS, this commit change the declaration to lower case.